### PR TITLE
Set default tuning

### DIFF
--- a/src/mts-dylib-reference.cpp
+++ b/src/mts-dylib-reference.cpp
@@ -3,17 +3,31 @@
 //
 
 #include <iostream>
+#include <cstring>
+#include <math.h>
 
-#define LOGDAT std::cout << __func__ << " " << __FILE__ << ":" << __LINE__ << " | ";
-#define LOGFN LOGDAT << std::endl
+#define LOGDAT std::cout << __func__ << " " << __FILE__ << ":" << __LINE__ << " | "
+#define LOGFN LOGDAT << std::endl;
+
+static bool tuningInitialized = false;
+static void setDefaultTuning(double *t)
+{
+   for (int i=0;i<128;i++) t[i]=440.*pow(2.,(i-69.)/12.);
+}
 
 extern "C"
 {
    // Master-side API
    static bool hasMaster{false};
+   double tuning[128];
    void MTS_RegisterMaster(void *) {
       LOGFN;
       hasMaster = true;
+      if (!tuningInitialized)
+      {
+         setDefaultTuning(tuning);
+         tuningInitialized = true;
+      }
    }
    void MTS_DeregisterMaster() {
       LOGFN;
@@ -28,16 +42,18 @@ extern "C"
       LOGFN;
       return false;
    }
+   int numClients{0};
    void MTS_Reinitialize() {
       LOGFN;
+      hasMaster = false;
+      numClients = 0;
+      setDefaultTuning(tuning);
    }
 
-   int numClients{0};
    int MTS_GetNumClients() {
       return numClients;
    }
 
-   double tuning[128];
    void MTS_SetNoteTunings(const double *d)
    {
       LOGFN;


### PR DESCRIPTION
Hi Paul,

I hope you're well :) @carlhenrikrolf has been using the mts-dylib-reference libMTS.so on a Raspberry Pi and saw some synths crashing - there's some more details in [this comment](https://github.com/narenratan/mtsespy/issues/1#issuecomment-2205252428) on an mtsespy issue but I believe the problem came from the MTS-ESP tuning table in mts-dylib-reference being initialized to 0.0.

I've done some tests with the official libMTS.so and the tuning table appears to be initialized to 12TET. This branch is my attempt to match the official behaviour. I added some mtsespy tests [here](https://github.com/narenratan/mtsespy/blob/main/tests/test_mtsespy.py#L39-L70) to test the tuning table initialization; they pass with the official libMTS.so and with the mts-dylib-reference libMTS.so from this branch.

I made a separate PR from the IPC PR seeing as the tuning table initialization change is independent. If it would be more convenient I could certainly push these changes to the ipc branch and close this PR. Apologies for my C++ as always!

Cheers,

Naren